### PR TITLE
Fix CreateEmptyFile truncation

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -19,12 +19,12 @@ const (
 // CreateEmptyFile 空ファイルを作成する
 func CreateEmptyFile(name string) error {
 	prefix := time.Now().Format(FileFormat)
-	f, err := os.OpenFile(fmt.Sprintf(prefix, name), os.O_RDONLY|os.O_CREATE, 0666)
+	// ensure the file is created and truncated to zero bytes
+	f, err := os.OpenFile(fmt.Sprintf(prefix, name), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}
-	f.Close()
-	return nil
+	return f.Close()
 }
 
 // CreateDir ディレクトリを作成する


### PR DESCRIPTION
## Summary
- correct CreateEmptyFile to always create an empty file

## Testing
- `gofmt -w common/common.go cmd/mkdatedir/main.go cmd/mkdatememo/main.go cmd/updatepath/main.go`


------
https://chatgpt.com/codex/tasks/task_e_6843e61246fc832dacc571e87ee70d48